### PR TITLE
fix: mark password as isSecret in config schema

### DIFF
--- a/cmd/baton-pingfederate/config.go
+++ b/cmd/baton-pingfederate/config.go
@@ -19,6 +19,7 @@ var (
 		"password",
 		field.WithDescription("Ping Federate account password"),
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 	)
 
 	configurationFields = []field.SchemaField{


### PR DESCRIPTION
## Summary

Marks credential field(s) `password` (Ping Federate account password) as secret in this connector's config so the credential is stored and handled as a secret rather than plaintext.

This connector defines its config in Go (`field` package), not a `config.yaml`. Secret-ness is the `field.WithIsSecret(true)` option on the field — the authoritative source. There is no committed `config_schema.json` in this repo, and the generated `conf.gen.go` is a mapstructure struct that carries no secret metadata, so the one-line `config.go` change is the complete fix and a CI regen produces no additional diff (no race).

## BREAKING

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

## Audit

Part of the connector config secret-ness audit (phase 13). Found via systematic review of credential fields lacking `isSecret`.

Do not merge — left open for review.

<!-- stargate: connector-secret-audit-phase13 -->